### PR TITLE
Makes "missing" pickleable

### DIFF
--- a/brownie/datastructures/__init__.py
+++ b/brownie/datastructures/__init__.py
@@ -19,6 +19,10 @@ class missing(object):
     def __repr__(self):
         return 'missing'
 
+    # pickle support -- just return our global name
+    def __reduce__(self):
+        return 'missing'
+
 #: Sentinel object which can be used instead of ``None``. This is useful if
 #: you have optional parameters to which a user can pass ``None`` e.g. in
 #: datastructures.

--- a/brownie/tests/datastructures/__init__.py
+++ b/brownie/tests/datastructures/__init__.py
@@ -27,6 +27,14 @@ class TestMissing(TestBase):
     def repr(self):
         Assert(repr(missing)) == 'missing'
 
+    @test
+    def pickleable(self):
+        import pickle
+        pickled = pickle.dumps(missing)
+        unpickled = pickle.loads(pickled)
+        if unpickled is not missing:
+            raise AssertionError()
+
 
 class TestStackedObject(TestBase):
     @test


### PR DESCRIPTION
We had some objects using "missing" that needed pickled, but because missing's class is not accessible by name.  This makes it pickleable by returning the name of the "missing" global, and there's a test verifying that the instance of "missing" returned when unpickling is the same global instance.
